### PR TITLE
fix the issue that the custom_labels will be overwritten

### DIFF
--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -1622,7 +1622,7 @@ def field2bytes(field, value, custom_labels=None):
     # allow use of custom labels
     label_table = ann_label_table
     if custom_labels is not None:
-        label_table = pd.concat([label_table, custom_labels], ignore_index=True)
+        label_table = pd.concat([custom_labels, label_table], ignore_index=True)
 
     # samp and sym bytes come together
     if field == "samptype":


### PR DESCRIPTION
The custom labels are overwritten by preset labels if the labels have the same symbol